### PR TITLE
add pub keys to known hosts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,4 +17,7 @@ hetzner_installimage_install_partitions:
 hetzner_installimage_install_image: /root/.oldroot/nfs/images/Ubuntu-1604-xenial-64-minimal.tar.gz
 # prevent reinstallation of running servers with /etc/hostcode file
 hetzner_installimage_ignore_hostcode: False
+
+# know hosts file location on ansible control node
+hetzner_installimage_known_hosts_file: "{{ lookup('env','HOME') + '/.ssh/known_hosts' }}"
 ...

--- a/tasks/add_server_to_known_hosts.yml
+++ b/tasks/add_server_to_known_hosts.yml
@@ -1,0 +1,14 @@
+---
+- name: scan for server's public key
+  shell: "ssh-keyscan -t ecdsa {{ ansible_host }}"
+  register: ssh_known_host_results
+  ignore_errors: yes
+  delegate_to: localhost
+
+- name: ensure the server's public key in known_hosts exists
+  known_hosts:
+    name: "{{ ansible_host }}"
+    key: "{{ ssh_known_host_results.stdout }}"
+    path: "{{ hetzner_installimage_known_hosts_file }}"
+  delegate_to: localhost
+...

--- a/tasks/add_server_to_known_hosts.yml
+++ b/tasks/add_server_to_known_hosts.yml
@@ -1,13 +1,13 @@
 ---
 - name: scan for server's public key
-  shell: "ssh-keyscan -t ecdsa {{ ansible_host }}"
+  shell: "ssh-keyscan -t ecdsa {{ inventory_hostname }}"
   register: ssh_known_host_results
   ignore_errors: yes
   delegate_to: localhost
 
 - name: ensure the server's public key in known_hosts exists
   known_hosts:
-    name: "{{ ansible_host }}"
+    name: "{{ inventory_hostname }}"
     key: "{{ ssh_known_host_results.stdout }}"
     path: "{{ hetzner_installimage_known_hosts_file }}"
   delegate_to: localhost

--- a/tasks/installimage.yml
+++ b/tasks/installimage.yml
@@ -47,6 +47,8 @@
     timeout: 180
   delegate_to: localhost
 
+- include: add_server_to_known_hosts.yml
+
 # uses raw instead of module as python might not be installed yet
 - name: install python on remote host
   raw: apt-get install python -y

--- a/tasks/rescuemode.yml
+++ b/tasks/rescuemode.yml
@@ -54,3 +54,5 @@
     delay: 1
     timeout: 180
   delegate_to: localhost
+
+- include: add_server_to_known_hosts.yml


### PR DESCRIPTION
removes the need to manually intervene during playbook execution just for the server pub keys. and I do not like having to use host key checking false :)