### PR TITLE
fix 'TERM is undefined' error by explicitly setting the variable

### DIFF
--- a/tasks/installimage.yml
+++ b/tasks/installimage.yml
@@ -33,6 +33,8 @@
   register: result
   vars:
     ansible_python_interpreter: "{{ hetzner_installimage_rescue_python }}"
+  environment:
+    TERM: xterm
 
 - name: do another hardware reset
   uri:


### PR DESCRIPTION
This fixes the 

```
TERM environment variable not set.
Error opening terminal: unknown.
```

error in the `run installimage` task that I sometimes encountered in my environment.