### PR TITLE
change rescue image python binary to python3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,5 +24,5 @@ hetzner_installimage_wait_timeout_after_reset: 180
 hetzner_installimage_handle_known_hosts: False
 
 # which python interpreter to be use on the rescue system
-hetzner_installimage_rescue_python: /usr/bin/python
+hetzner_installimage_rescue_python: /usr/bin/python3
 ...


### PR DESCRIPTION
rescue image seems to have changed its default to /usr/bin/python3.